### PR TITLE
Fixed: Exception stack trace was incomplete when parsing a script

### DIFF
--- a/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs
+++ b/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs
@@ -30,7 +30,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 			catch (SyntaxErrorException ex)
 			{
 				ex.DecorateMessage(script);
-				throw;
+                throw new Exception(null, ex);
 			}
 		}
 
@@ -74,7 +74,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 			catch (SyntaxErrorException ex)
 			{
 				ex.DecorateMessage(script);
-				throw;
+                throw new Exception(null, ex);
 			}
 		}
 
@@ -108,7 +108,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 			catch (SyntaxErrorException ex)
 			{
 				ex.DecorateMessage(script);
-				throw;
+                throw new Exception(null, ex);
 			}
 
 		}


### PR DESCRIPTION
I was trying MoonSharp with Unity. When passing the following script to LoadString, an exception was raised. However, the stack trace was incomplete.

Lua script:
~~~lua
-- defines a factorial function
function fact(n)
    if (n == 0) then
        return 1
    else
        return n * fact(n - 1)
end
~~~

Original exception:
~~~
SyntaxErrorException: 'end' expected near '<eof>'
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression.CreateBody (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:95)
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean pushSelfParam, MoonSharp.Interpreter.Table globalContext, Boolean isLambda) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:69)
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean pushSelfParam, Boolean isLambda) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:32)
MoonSharp.Interpreter.Tree.Statements.FunctionDefinitionStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean local, MoonSharp.Interpreter.Tree.Token localToken) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs:89)
MoonSharp.Interpreter.Tree.Statement.CreateStatement (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, System.Boolean& forceLast) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statement.cs:47)
MoonSharp.Interpreter.Tree.Statements.CompositeStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/CompositeStatement.cs:25)
MoonSharp.Interpreter.Tree.Statements.ChunkStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, MoonSharp.Interpreter.Table globalEnv) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/ChunkStatement.cs:31)
MoonSharp.Interpreter.Tree.Fast_Interface.Loader_Fast.LoadChunk (MoonSharp.Interpreter.Script script, MoonSharp.Interpreter.Debugging.SourceCode source, MoonSharp.Interpreter.Execution.VM.ByteCode bytecode, MoonSharp.Interpreter.Table globalContext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs:55)
UnityEngine.EventSystems.EventSystem:Update()
~~~

Current exception:
~~~
SyntaxErrorException: 'end' expected near '<eof>'
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression.CreateBody (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:95)
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean pushSelfParam, MoonSharp.Interpreter.Table globalContext, Boolean isLambda) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:69)
MoonSharp.Interpreter.Tree.Expressions.FunctionDefinitionExpression..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean pushSelfParam, Boolean isLambda) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs:32)
MoonSharp.Interpreter.Tree.Statements.FunctionDefinitionStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, Boolean local, MoonSharp.Interpreter.Tree.Token localToken) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs:89)
MoonSharp.Interpreter.Tree.Statement.CreateStatement (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, System.Boolean& forceLast) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statement.cs:47)
MoonSharp.Interpreter.Tree.Statements.CompositeStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/CompositeStatement.cs:25)
MoonSharp.Interpreter.Tree.Statements.ChunkStatement..ctor (MoonSharp.Interpreter.Execution.ScriptLoadingContext lcontext, MoonSharp.Interpreter.Table globalEnv) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Statements/ChunkStatement.cs:31)
MoonSharp.Interpreter.Tree.Fast_Interface.Loader_Fast.LoadChunk (MoonSharp.Interpreter.Script script, MoonSharp.Interpreter.Debugging.SourceCode source, MoonSharp.Interpreter.Execution.VM.ByteCode bytecode, MoonSharp.Interpreter.Table globalContext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs:55)
Rethrow as Exception: Exception of type 'System.Exception' was thrown.
MoonSharp.Interpreter.Tree.Fast_Interface.Loader_Fast.LoadChunk (MoonSharp.Interpreter.Script script, MoonSharp.Interpreter.Debugging.SourceCode source, MoonSharp.Interpreter.Execution.VM.ByteCode bytecode, MoonSharp.Interpreter.Table globalContext) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs:77)
MoonSharp.Interpreter.Script.LoadString (System.String code, MoonSharp.Interpreter.Table globalTable, System.String codeFriendlyName) (at c:/Workspace/Unity/moonsharp/src/MoonSharp.Interpreter/Script.cs:187)
Moon01.Calculate (System.String newValue) (at Assets/__Protal__/Scripts/Moon01.cs:13)
UnityEngine.Events.InvokableCall`1[System.String].Invoke (System.Object[] args) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:168)
UnityEngine.Events.InvokableCallList.Invoke (System.Object[] parameters) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:602)
UnityEngine.Events.UnityEventBase.Invoke (System.Object[] parameters) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent.cs:744)
UnityEngine.Events.UnityEvent`1[T0].Invoke (.T0 arg0) (at C:/buildslave/unity/build/Runtime/Export/UnityEvent_1.cs:53)
UnityEngine.UI.InputField.SendOnSubmit () (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/InputField.cs:1334)
UnityEngine.UI.InputField.DeactivateInputField () (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/InputField.cs:2011)
UnityEngine.UI.InputField.OnUpdateSelected (UnityEngine.EventSystems.BaseEventData eventData) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/InputField.cs:1025)
UnityEngine.EventSystems.ExecuteEvents.Execute (IUpdateSelectedHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:101)
UnityEngine.EventSystems.ExecuteEvents.Execute[IUpdateSelectedHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) (at C:/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:269)
UnityEngine.EventSystems.EventSystem:Update()
~~~

BTW, other catch-rethrow code in MoonSharp may have the same problem.