### PR TITLE
Adjusted file stream to allow shared access.

### DIFF
--- a/src/MoonSharp.Interpreter/Loaders/FileSystemScriptLoader.cs
+++ b/src/MoonSharp.Interpreter/Loaders/FileSystemScriptLoader.cs
@@ -35,7 +35,7 @@ namespace MoonSharp.Interpreter.Loaders
 		/// </returns>
 		public override object LoadFile(string file, Table globalContext)
 		{
-			return new FileStream(file, FileMode.Open, FileAccess.Read);
+			return new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 		}
 	}
 }


### PR DESCRIPTION
An issue I ran into with having auto-refreshing scripts via FileSystemWatcher objects was that the Stream being opened is not disposed right away for scripts. A script loaded with the default FileSystemScriptLoader doesn't offer shared file access and takes a "greedy" lock onto the file.

This is a small fix to allow shared access to the file.