### PR TITLE
Remove environment tables from bytecode

### DIFF
--- a/src/MoonSharp.Interpreter/Script.cs
+++ b/src/MoonSharp.Interpreter/Script.cs
@@ -126,12 +126,12 @@ namespace MoonSharp.Interpreter
 
 			m_Sources.Add(source);
 
-			int address = Loader_Fast.LoadFunction(this, source, m_ByteCode, globalTable ?? m_GlobalTable);
+			int address = Loader_Fast.LoadFunction(this, source, m_ByteCode, globalTable != null || m_GlobalTable != null);
 
 			SignalSourceCodeChange(source);
 			SignalByteCodeChange();
 
-			return MakeClosure(address);
+			return MakeClosure(address, globalTable ?? m_GlobalTable);
 		}
 
 		private void SignalByteCodeChange()
@@ -180,13 +180,12 @@ namespace MoonSharp.Interpreter
 
 			int address = Loader_Fast.LoadChunk(this,
 				source,
-				m_ByteCode,
-				globalTable ?? m_GlobalTable);
+				m_ByteCode);
 
 			SignalSourceCodeChange(source);
 			SignalByteCodeChange();
 
-			return MakeClosure(address);
+			return MakeClosure(address, globalTable ?? m_GlobalTable);
 		}
 
 		/// <summary>

--- a/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -17,25 +17,25 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		bool m_HasVarArgs = false;
 		Instruction m_ClosureInstruction = null;
 
-		Table m_GlobalEnv;
+		bool m_UsesGlobalEnv;
 		SymbolRef m_Env;
 
 		SourceRef m_Begin, m_End;
 
 
-		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, Table globalContext)
-			: this(lcontext, false, globalContext, false)
+		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool usesGlobalEnv)
+			: this(lcontext, false, usesGlobalEnv, false)
 		{ }
 
 		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool pushSelfParam, bool isLambda)
-			: this(lcontext, pushSelfParam, null, isLambda)
+			: this(lcontext, pushSelfParam, false, isLambda)
 		{ }
 
 
-		private FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool pushSelfParam, Table globalContext, bool isLambda)
+		private FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool pushSelfParam, bool usesGlobalEnv, bool isLambda)
 			: base(lcontext)
 		{
-			if (globalContext != null)
+			if (m_UsesGlobalEnv = usesGlobalEnv)
 				CheckTokenType(lcontext, TokenType.Function);
 
 			// here lexer should be at the '(' or at the '|'
@@ -49,9 +49,8 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 			// create scope
 			lcontext.Scope.PushFunction(this, m_HasVarArgs);
 
-			if (globalContext != null)
+			if (m_UsesGlobalEnv)
 			{
-				m_GlobalEnv = globalContext;
 				m_Env = lcontext.Scope.DefineLocal(WellKnownSymbols.ENV);
 			}
 			else
@@ -207,9 +206,9 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 
 			int entryPoint = bc.GetJumpPointForLastInstruction();
 
-			if (m_GlobalEnv != null)
+			if (m_UsesGlobalEnv)
 			{
-				bc.Emit_Literal(DynValue.NewTable(m_GlobalEnv));
+				bc.Emit_Load(SymbolRef.Upvalue(WellKnownSymbols.ENV, 0));
 				bc.Emit_Store(m_Env, 0, 0);
 				bc.Emit_Pop();
 			}

--- a/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs
+++ b/src/MoonSharp.Interpreter/Tree/Fast_Interface/Loader_Fast.cs
@@ -40,7 +40,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 			};
 		}
 
-		internal static int LoadChunk(Script script, SourceCode source, ByteCode bytecode, Table globalContext)
+		internal static int LoadChunk(Script script, SourceCode source, ByteCode bytecode)
 		{
 			ScriptLoadingContext lcontext = CreateLoadingContext(script, source);
 			try
@@ -48,7 +48,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 				Statement stat;
 
 				using (script.PerformanceStats.StartStopwatch(Diagnostics.PerformanceCounter.AstCreation))
-					stat = new ChunkStatement(lcontext, globalContext);
+					stat = new ChunkStatement(lcontext);
 
 				int beginIp = -1;
 
@@ -74,7 +74,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 			}
 		}
 
-		internal static int LoadFunction(Script script, SourceCode source, ByteCode bytecode, Table globalContext)
+		internal static int LoadFunction(Script script, SourceCode source, ByteCode bytecode, bool usesGlobalEnv)
 		{
 			ScriptLoadingContext lcontext = CreateLoadingContext(script, source);
 
@@ -83,7 +83,7 @@ namespace MoonSharp.Interpreter.Tree.Fast_Interface
 				FunctionDefinitionExpression fnx;
 
 				using (script.PerformanceStats.StartStopwatch(Diagnostics.PerformanceCounter.AstCreation))
-					fnx = new FunctionDefinitionExpression(lcontext, globalContext);
+					fnx = new FunctionDefinitionExpression(lcontext, usesGlobalEnv);
 
 				int beginIp = -1;
 


### PR DESCRIPTION
A stab at what was discussed [here](https://groups.google.com/forum/#!topic/moonsharp/xSd4NYpeSKQ).

I've just moved the functions' and chunks' environments into their closure instead of having it sit in the bytecode. This way the tables are properly disposed of once all outstanding references are closed. I've checked logically in the code that it does not adversely affect other use cases and it seems to me that it should be fine.

It currently works well with my code without any obvious side effects. I will keep an eye out on any possible problems.