### PR TITLE
Refactored Table class's Set/Get methods, added RawGet/Remove methods

### DIFF
--- a/src/MoonSharp.Interpreter/DataStructs/LinkedListIndex.cs
+++ b/src/MoonSharp.Interpreter/DataStructs/LinkedListIndex.cs
@@ -82,15 +82,17 @@ namespace MoonSharp.Interpreter.DataStructs
 		/// Removes the specified key from the index, and the node indexed by the key from the linked list.
 		/// </summary>
 		/// <param name="key">The key.</param>
-		public void Remove(TKey key)
+		public bool Remove(TKey key)
 		{
 			LinkedListNode<TValue> node = Find(key);
 
 			if (node != null)
 			{
 				m_LinkedList.Remove(node);
-				m_Map.Remove(key);
+				return m_Map.Remove(key);
 			}
+
+			return false;
 		}
 
 

--- a/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
@@ -827,9 +827,18 @@ namespace MoonSharp.Interpreter
 		/// <summary>
 		/// Converts this MoonSharp DynValue to a CLR object of the specified type.
 		/// </summary>
+		public object ToObject(Type desiredType)
+		{
+			//Contract.Requires(desiredType != null);
+			return MoonSharp.Interpreter.Interop.Converters.ScriptToClrConversions.DynValueToObjectOfType(this, desiredType, null, false);
+		}
+
+		/// <summary>
+		/// Converts this MoonSharp DynValue to a CLR object of the specified type.
+		/// </summary>
 		public T ToObject<T>()
 		{
-			return (T)MoonSharp.Interpreter.Interop.Converters.ScriptToClrConversions.DynValueToObjectOfType(this, typeof(T), null, false);
+			return (T)ToObject(typeof(T));
 		}
 
 #if HASDYNAMIC


### PR DESCRIPTION
Hi Xanathar,

I did some refactoring on the Table class's Set/Get methods to get them to be 
more symmetrical. Each method now has an overload for string, integer, DynValue 
and object keys as well as a method with multiple keys for easier lookup in sub-tables.

I added a set of RawGet methods that return null if item is not found. The Get methods
is all guaranteed to return a non-null DynValue.  A Nil is returned by Get when a key is
not found, and RawGet return null when a key was not found. I needed this distinction
for places where I needed to determine if a key exist in the table.

I added a set of Remove methods to remove a key from the Table object. I had a scenario 
where I just needed to remove an item and did not want to go through the Set methods. 
Also I wanted to know if the item was actually removed or not, hence the boolean return.

Lastly I added an Append helper method to append a value to the table using the next
available integer index.

Regards,
  Francois