### PR TITLE
Table remove by negative fix

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
@@ -170,29 +170,37 @@ namespace MoonSharp.Interpreter.CoreLib
 		public static DynValue remove(ScriptExecutionContext executionContext, CallbackArguments args)
 		{
 			DynValue vlist = args.AsType(0, "table.remove", DataType.Table, false);
-			DynValue vpos = args.AsType(1, "table.remove", DataType.Number, true);
-			DynValue ret = DynValue.Nil;
 
-			if (args.Count > 2)
-				throw new ScriptRuntimeException("wrong number of arguments to 'remove'");
+            if (args[1].Type != DataType.Number)
+            {
+                throw new ScriptRuntimeException(string.Format( "bad argument #2 to 'remove' (number expected, got {0})", args[1].Type.ToLuaTypeString()));
+            }
+            else
+            {
+                DynValue vpos = args.AsType(1, "table.remove", DataType.Number, true);
+                DynValue ret = DynValue.Nil;
 
-			int len = GetTableLength(executionContext, vlist);
-			Table list = vlist.Table;
+                if (args.Count > 2)
+                    throw new ScriptRuntimeException("wrong number of arguments to 'remove'");
 
-			int pos = vpos.IsNil() ? len : (int)vpos.Number;
+                int len = GetTableLength(executionContext, vlist);
+                Table list = vlist.Table;
 
-			if (pos >= len + 1 || (pos < 0))
-				throw new ScriptRuntimeException("bad argument #1 to 'remove' (position out of bounds)");
+                int pos = vpos.IsNil() ? len : (int)vpos.Number;
 
-			for (int i = pos; i <= len; i++)
-			{
-				if (i == pos)
-					ret = list.Get(i);
+                if (pos >= len + 1 || (pos < 0) || (pos == 0 && len > 0 /*this odd behaviour also occur in pure lua - don't throw exception if we try to delete 0 index of empty table(!)*/))
+                    throw new ScriptRuntimeException("bad argument #1 to 'remove' (position out of bounds)");
 
-				list.Set(i, list.Get(i + 1));
-			}
+                for (int i = pos; i <= len; i++)
+                {
+                    if (i == pos)
+                        ret = list.Get(i);
 
-			return ret;
+                    list.Set(i, list.Get(i + 1));
+                }
+
+                return ret;
+            }
 		}
 
 

--- a/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
@@ -181,7 +181,7 @@ namespace MoonSharp.Interpreter.CoreLib
 
 			int pos = vpos.IsNil() ? len : (int)vpos.Number;
 
-			if (pos >= len + 1 || (pos < 1 && len > 0))
+			if (pos >= len + 1 || (pos < 0))
 				throw new ScriptRuntimeException("bad argument #1 to 'remove' (position out of bounds)");
 
 			for (int i = pos; i <= len; i++)

--- a/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/TableModule.cs
@@ -171,37 +171,40 @@ namespace MoonSharp.Interpreter.CoreLib
 		{
 			DynValue vlist = args.AsType(0, "table.remove", DataType.Table, false);
 
-            if (args[1].Type != DataType.Number)
+            switch (args[1].Type)
             {
-                throw new ScriptRuntimeException(string.Format( "bad argument #2 to 'remove' (number expected, got {0})", args[1].Type.ToLuaTypeString()));
+                case DataType.Nil:
+                    return DynValue.NewString("");
+
+                default:
+                    throw new ScriptRuntimeException(string.Format("bad argument #2 to 'remove' (number expected, got {0})", args[1].Type.ToLuaTypeString()));
+
+                case DataType.Number:
+                    DynValue vpos = args.AsType(1, "table.remove", DataType.Number, true);
+                    DynValue ret = DynValue.Nil;
+
+                    if (args.Count > 2)
+                        throw new ScriptRuntimeException("wrong number of arguments to 'remove'");
+
+                    int len = GetTableLength(executionContext, vlist);
+                    Table list = vlist.Table;
+
+                    int pos = vpos.IsNil() ? len : (int)vpos.Number;
+
+                    if (pos >= len + 1 || (pos < 0) || (pos == 0 && len > 0 /*this odd behaviour also occur in pure lua - don't throw exception if we try to delete 0 index of empty table(!)*/))
+                        throw new ScriptRuntimeException("bad argument #1 to 'remove' (position out of bounds)");
+
+                    for (int i = pos; i <= len; i++)
+                    {
+                        if (i == pos)
+                            ret = list.Get(i);
+
+                        list.Set(i, list.Get(i + 1));
+                    }
+
+                    return ret;
             }
-            else
-            {
-                DynValue vpos = args.AsType(1, "table.remove", DataType.Number, true);
-                DynValue ret = DynValue.Nil;
-
-                if (args.Count > 2)
-                    throw new ScriptRuntimeException("wrong number of arguments to 'remove'");
-
-                int len = GetTableLength(executionContext, vlist);
-                Table list = vlist.Table;
-
-                int pos = vpos.IsNil() ? len : (int)vpos.Number;
-
-                if (pos >= len + 1 || (pos < 0) || (pos == 0 && len > 0 /*this odd behaviour also occur in pure lua - don't throw exception if we try to delete 0 index of empty table(!)*/))
-                    throw new ScriptRuntimeException("bad argument #1 to 'remove' (position out of bounds)");
-
-                for (int i = pos; i <= len; i++)
-                {
-                    if (i == pos)
-                        ret = list.Get(i);
-
-                    list.Set(i, list.Get(i + 1));
-                }
-
-                return ret;
-            }
-		}
+        }
 
 
 		//table.concat (list [, sep [, i [, j]]])


### PR DESCRIPTION
More precise to pure lua behaviour : addional exception added, changed odd and improper check that caused table overflow upon passing something non-numerical as argument to table.remove(). 
table.remove now accept only numbers and nil as indices (same as pure lua does)
table.remove now does nothing if table is empty and passed index is 0 (same as pure lua does)
