### PR TITLE
Fixed Table.Clear crashing

### DIFF
--- a/src/MoonSharp.Interpreter/DataStructs/LinkedListIndex.cs
+++ b/src/MoonSharp.Interpreter/DataStructs/LinkedListIndex.cs
@@ -113,7 +113,8 @@ namespace MoonSharp.Interpreter.DataStructs
 		/// </summary>
 		public void Clear()
 		{
-			m_Map.Clear();
+            if(m_Map != null)
+			    m_Map.Clear();
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/DataTypes/Table.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/Table.cs
@@ -62,6 +62,7 @@ namespace MoonSharp.Interpreter
 			m_StringMap.Clear();
 			m_ArrayMap.Clear();
 			m_ValueMap.Clear();
+            m_CachedLength = -1;
 		}
 
 		/// <summary>


### PR DESCRIPTION
-Added null check to LinkedListIndex's clear on its m_map
-Reset Table's length after Clear

Please comment or modify it if I'm off the mark.
