### PR TITLE
Pass the module name as a parameter to modules loaded with require

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/LoadModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/LoadModule.cs
@@ -231,7 +231,7 @@ function(modulename)
 
 	local func = __require_clr_impl(modulename);
 
-	local res = func();
+	local res = func(modulename);
 
 	package.loaded[modulename] = res;
 


### PR DESCRIPTION
This allows a required module to load another module through a path relative to itself.

More information on this SO post: http://stackoverflow.com/a/18157802

