### PR TITLE
Make offset-parameter of seek optional, fixes #170

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/IO/FileUserDataBase.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/IO/FileUserDataBase.cs
@@ -211,7 +211,7 @@ namespace MoonSharp.Interpreter.CoreLib.IO
 		protected abstract string Close();
 
 		public abstract bool flush();
-		public abstract long seek(string whence, long offset);
+		public abstract long seek(string whence, long offset = 0);
 		public abstract bool setvbuf(string mode);
 
 		public override string ToString()

--- a/src/MoonSharp.Interpreter/CoreLib/IO/StreamFileUserDataBase.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/IO/StreamFileUserDataBase.cs
@@ -97,7 +97,7 @@ namespace MoonSharp.Interpreter.CoreLib.IO
 			return true;
 		}
 
-		public override long seek(string whence, long offset)
+		public override long seek(string whence, long offset = 0)
 		{
 			CheckFileIsNotClosed();
 			if (whence != null)


### PR DESCRIPTION
Fix #170 by making the `offset`-Parameter of the `seek()` implementation optional.