### PR TITLE
No NullReferenceException when passing null to Table.Set

### DIFF
--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/JsonSerializationTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/JsonSerializationTests.cs
@@ -58,6 +58,9 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 
 			Assert.AreEqual(DataType.String, s.Get("aString").Type);
 			Assert.AreEqual("8", s.Get("aString").String);
+
+			Assert.AreEqual(DataType.Number, t.Get("aNegativeNumber").Type);
+			Assert.AreEqual(-9, t.Get("aNegativeNumber").Number);
 		}
 
 
@@ -68,7 +71,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 				'aNumber' : 1,
 				'aString' : '2',
 				'anObject' : { 'aNumber' : 3, 'aString' : '4' },
-				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ]
+				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ],
+				'aNegativeNumber' : -9
 				}
 			".Replace('\'', '\"');
 
@@ -83,7 +87,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 				'aNumber' : 1,
 				'aString' : '2',
 				'anObject' : { 'aNumber' : 3, 'aString' : '4' },
-				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ]
+				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ],
+				'aNegativeNumber' : -9
 				}
 			".Replace('\'', '\"');
 
@@ -120,7 +125,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 						aNumber = 7,
 						aString = "8"
 					}
-				}
+				},
+				aNegativeNumber = -9
 			};
 
 

--- a/src/MoonSharp.Interpreter/Compatibility/Frameworks/Base/FrameworkClrBase.cs
+++ b/src/MoonSharp.Interpreter/Compatibility/Frameworks/Base/FrameworkClrBase.cs
@@ -10,7 +10,7 @@ namespace MoonSharp.Interpreter.Compatibility.Frameworks
 {
 	abstract class FrameworkClrBase : FrameworkReflectionBase
 	{
-		BindingFlags BINDINGFLAGS_MEMBER = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+		BindingFlags BINDINGFLAGS_MEMBER = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy;
 		BindingFlags BINDINGFLAGS_INNERCLASS = BindingFlags.Public | BindingFlags.NonPublic;
 
 		public override MethodInfo GetAddMethod(EventInfo ei)

--- a/src/MoonSharp.Interpreter/DataTypes/Table.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/Table.cs
@@ -161,6 +161,12 @@ namespace MoonSharp.Interpreter
 
 		private void PerformTableSet<T>(LinkedListIndex<T, TablePair> listIndex, T key, DynValue keyDynValue, DynValue value, bool isNumber, int appendKey)
 		{
+			if (value == null)
+			{
+				PerformTableRemove(listIndex, key, isNumber);
+				return;
+			}
+
 			TablePair prev = listIndex.Set(key, new TablePair(keyDynValue, value));
 
 			// If this is an insert, we can invalidate all iterators and collect dead keys

--- a/src/MoonSharp.Interpreter/Serialization/Json/JsonTableConverter.cs
+++ b/src/MoonSharp.Interpreter/Serialization/Json/JsonTableConverter.cs
@@ -214,9 +214,9 @@ namespace MoonSharp.Interpreter.Serialization.Json
 			{
 				return DynValue.NewString(L.Current.Text);
 			}
-			else if (L.Current.Type == TokenType.Number)
+			else if (L.Current.Type == TokenType.Number || L.Current.Type == TokenType.Op_MinusOrSub)
 			{
-				return DynValue.NewNumber(L.Current.GetNumberValue()).AsReadOnly();
+				return ParseJsonNumberValue(L, script);
 			}
 			else if (L.Current.Type == TokenType.True)
 			{
@@ -234,6 +234,31 @@ namespace MoonSharp.Interpreter.Serialization.Json
 			{
 				throw new SyntaxErrorException(L.Current, "Unexpected token : '{0}'", L.Current.Text);
 			}
+		}
+
+		private static DynValue ParseJsonNumberValue(Lexer L, Script script)
+		{
+			bool negative;
+			if (L.Current.Type == TokenType.Op_MinusOrSub)
+			{
+				// Negative number consists of 2 tokens.
+				L.Next();
+				negative = true;
+			}
+			else
+			{
+				negative = false;
+			}
+			if (L.Current.Type != TokenType.Number)
+			{
+				throw new SyntaxErrorException(L.Current, "Unexpected token : '{0}'", L.Current.Text);
+			}
+			var numberValue = L.Current.GetNumberValue();
+			if (negative)
+			{
+				numberValue = -numberValue;
+			}
+			return DynValue.NewNumber(numberValue).AsReadOnly();
 		}
 	}
 }


### PR DESCRIPTION
Passing null as value parameter in any of the Table.Set overloads causes a NullReferenceException in Table.PerformTableSet. I propose either a proper ArgumentNullException, or giving null a reasonable meaning. Considering the similarity to setting the value to nil (instead of null) it might be reasonable to assume that the intent of the user in this case is to remove the value from the table.