### PR TITLE
No NullReferenceException when passing null to Table.Set

### DIFF
--- a/src/MoonSharp.Interpreter/DataTypes/Table.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/Table.cs
@@ -161,6 +161,12 @@ namespace MoonSharp.Interpreter
 
 		private void PerformTableSet<T>(LinkedListIndex<T, TablePair> listIndex, T key, DynValue keyDynValue, DynValue value, bool isNumber, int appendKey)
 		{
+			if (value == null)
+			{
+				PerformTableRemove(listIndex, key, isNumber);
+				return;
+			}
+
 			TablePair prev = listIndex.Set(key, new TablePair(keyDynValue, value));
 
 			// If this is an insert, we can invalidate all iterators and collect dead keys

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/DataTypes/Table.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/DataTypes/Table.cs
@@ -161,6 +161,12 @@ namespace MoonSharp.Interpreter
 
 		private void PerformTableSet<T>(LinkedListIndex<T, TablePair> listIndex, T key, DynValue keyDynValue, DynValue value, bool isNumber, int appendKey)
 		{
+			if (value == null)
+			{
+				PerformTableRemove(listIndex, key, isNumber);
+				return;
+			}
+
 			TablePair prev = listIndex.Set(key, new TablePair(keyDynValue, value));
 
 			// If this is an insert, we can invalidate all iterators and collect dead keys


### PR DESCRIPTION
Passing null as value parameter in any of the Table.Set overloads causes a NullReferenceException in Table.PerformTableSet. I propose either a proper ArgumentNullException, or giving null a reasonable meaning. Considering the similarity to setting the value to nil (instead of null) it might be reasonable to assume that the intent of the user in this case is to remove the value from the table.