### PR TITLE
Fix stringlib against non-ascii chars

### DIFF
--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
@@ -248,6 +248,30 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			TestMatch(s, p, true);
 		}
 
+		[Test]
+		public void String_Match_2()
+		{
+			string s = "糸筍"; // U+7CF8, U+7B4D
+			string p = "書籍"; // U+66F8, U+7C4D
+
+			TestMatch(s, p, false);
+		}
+
+		[Test]
+		public void String_Match_3()
+		{
+			// maxexpand
+			string s = "書籍籍筍筍筍"; // U+66F8, U+7C4D, U+7B4D, ...
+			string p = "書籍+"; // U+66F8, U+7C4D
+
+			Script S = new Script(CoreModules.String);
+			S.Globals["s"] = s;
+			S.Globals["p"] = p;
+			DynValue res = S.DoString("return string.match(s, p)");
+
+			Utils.DynAssert(res, "書籍籍");
+		}
+
 		private void TestMatch(string s, string p, bool expected)
 		{
 			Script S = new Script(CoreModules.String);

--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
@@ -272,6 +272,15 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			Utils.DynAssert(res, "書籍籍");
 		}
 
+		[Test]
+		public void String_Match_4()
+		{
+			string s = "㍝"; // U+335D
+			string p = "[Aそ]"; // U+005B, U+0041, U+305D, U+005D
+
+			TestMatch(s, p, false);
+		}
+
 		private void TestMatch(string s, string p, bool expected)
 		{
 			Script S = new Script(CoreModules.String);

--- a/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
@@ -357,15 +357,15 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 														   LUA_QL("%f") + " in pattern");
 									ep = classend(ms, p);  /* points to what is next */
 									previous = (s == ms.src_init) ? '\0' : s[-1];
-									if ((matchbracketclass((byte)(previous), p, ep - 1) != 0) ||
-									   (matchbracketclass((byte)(s[0]), p, ep - 1) == 0)) return null;
+									if ((matchbracketclass(previous, p, ep - 1) != 0) ||
+									   (matchbracketclass(s[0], p, ep - 1) == 0)) return null;
 									p = ep; goto init;  /* else return match(ms, s, ep); */
 								}
 							default:
 								{
 									if (isdigit((char)(p[1])))
 									{  /* capture results (%0-%9)? */
-										s = match_capture(ms, s, (byte)(p[1]));
+										s = match_capture(ms, s, p[1]);
 										if (s == null) return null;
 										p += 2; goto init;  /* else return match(ms, s, p+2) */
 									}
@@ -857,15 +857,15 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 			while (p[0] != '\0' && strchr(FLAGS, p[0]) != null) p = p.next();  /* skip flags */
 			if ((uint)(p - strfrmt) >= (FLAGS.Length + 1))
 				LuaLError(L, "invalid format (repeated flags)");
-			if (isdigit((byte)(p[0]))) p = p.next();  /* skip width */
-			if (isdigit((byte)(p[0]))) p = p.next();  /* (2 digits at most) */
+			if (isdigit(p[0])) p = p.next();  /* skip width */
+			if (isdigit(p[0])) p = p.next();  /* (2 digits at most) */
 			if (p[0] == '.')
 			{
 				p = p.next();
-				if (isdigit((byte)(p[0]))) p = p.next();  /* skip precision */
-				if (isdigit((byte)(p[0]))) p = p.next();  /* (2 digits at most) */
+				if (isdigit(p[0])) p = p.next();  /* skip precision */
+				if (isdigit(p[0])) p = p.next();  /* (2 digits at most) */
 			}
-			if (isdigit((byte)(p[0])))
+			if (isdigit(p[0]))
 				LuaLError(L, "invalid format (width or precision too long)");
 			form[0] = '%';
 			form = form.next();

--- a/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
@@ -203,10 +203,10 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				else if ((p[1] == '-') && (p + 2 < ec))
 				{
 					p += 2;
-					if ((byte)((p[-2])) <= c && (c <= (byte)p[0]))
+					if (p[-2] <= c && (c <= p[0]))
 						return sig;
 				}
-				else if ((byte)(p[0]) == c) return sig;
+				else if (p[0] == c) return sig;
 			}
 			return (sig == 0) ? 1 : 0;
 		}

--- a/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
@@ -219,10 +219,9 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				case '.': return 1;  /* matches any char */
 				case L_ESC: return match_class((char)c, (char)(p[1]));
 				case '[': return matchbracketclass(c, p, ep - 1);
-				default: return ((byte)(p[0]) == c) ? 1 : 0;
+				default: return (p[0] == c) ? 1 : 0;
 			}
 		}
-
 
 		private static CharPtr matchbalance(MatchState ms, CharPtr s,
 										   CharPtr p)
@@ -247,12 +246,11 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 			return null;  /* string ends out of balance */
 		}
 
-
 		private static CharPtr max_expand(MatchState ms, CharPtr s,
 										 CharPtr p, CharPtr ep)
 		{
 			ptrdiff_t i = 0;  /* counts maximum expand for item */
-			while ((s + i < ms.src_end) && (singlematch((byte)(s[i]), p, ep) != 0))
+			while ((s + i < ms.src_end) && (singlematch(s[i], p, ep) != 0))
 				i++;
 			/* keeps trying to match with the maximum repetitions */
 			while (i >= 0)
@@ -273,7 +271,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				CharPtr res = match(ms, s, ep + 1);
 				if (res != null)
 					return res;
-				else if ((s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0))
+				else if ((s < ms.src_end) && (singlematch(s[0], p, ep) != 0))
 					s = s.next();  /* try with one more repetition */
 				else return null;
 			}
@@ -374,7 +372,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 									//ismeretlen hiba miatt lett ide átmásolva
 									{  /* it is a pattern item */
 										CharPtr ep = classend(ms, p);  /* points to what is next */
-										int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+										int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 										switch (ep[0])
 										{
 											case '?':
@@ -421,7 +419,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				dflt:
 					{  /* it is a pattern item */
 						CharPtr ep = classend(ms, p);  /* points to what is next */
-						int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+						int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 						switch (ep[0])
 						{
 							case '?':


### PR DESCRIPTION
Some string functions ignore upper byte of chars of strings.
This causes unexpected behaviors.

ex)
* `"書籍"` (U+66F8, U+7C4D) matches `"糸筍"` (U+7CF8, U+7B4D)
* `"[Aそ]"` matches `"㍝"`

See the test cases.

I confirmed that all test in MoonSharp.Interpreter.Tests.net35-client passed using moonsharp_dev_minimal.sln.