### PR TITLE
Make TimeZone changeable

### DIFF
--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/TimeZoneTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/TimeZoneTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace MoonSharp.Interpreter.Tests.EndToEnd
+{
+	[TestFixture]
+	public class TimeZoneTests
+	{
+		[Test]
+		public void LocalTime1()
+		{
+			Script S = new Script();
+			S.Options.LocalTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
+
+			DynValue res = S.DoString("return os.date(\"%Y-%m-%d %H:%M:%S\", 0)");
+
+			Assert.AreEqual(DataType.String, res.Type);
+			Assert.AreEqual("1970-01-01 01:00:00", res.String);
+		}
+
+		[Test]
+		public void LocalTime2()
+		{
+			Script S = new Script();
+			S.Options.LocalTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
+
+			DynValue res = S.DoString("return os.date(\"!%Y-%m-%d %H:%M:%S\", 0)");
+
+			Assert.AreEqual(DataType.String, res.Type);
+			Assert.AreEqual("1970-01-01 00:00:00", res.String);
+		}
+
+		[Test]
+		public void LocalTime3()
+		{
+			Script S = new Script();
+
+			TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(1970, 1, 1));
+
+			DynValue res = S.DoString($"return os.date(\"%Y-%m-%d %H:%M:%S\", -{offset.TotalSeconds})");
+
+			Assert.AreEqual(DataType.String, res.Type);
+			Assert.AreEqual("1970-01-01 00:00:00", res.String);
+		}
+	}
+}

--- a/src/MoonSharp.Interpreter.Tests/MoonSharp.Interpreter.Tests.net35-client.csproj
+++ b/src/MoonSharp.Interpreter.Tests/MoonSharp.Interpreter.Tests.net35-client.csproj
@@ -135,6 +135,7 @@
     <Compile Include="EndToEnd\StringLibTests.cs" />
     <Compile Include="EndToEnd\StructAssignmentTechnique.cs" />
     <Compile Include="EndToEnd\TailCallTests.cs" />
+    <Compile Include="EndToEnd\TimeZoneTests.cs" />
     <Compile Include="EndToEnd\UserDataEventsTests.cs" />
     <Compile Include="EndToEnd\UserDataEnumsTest.cs" />
     <Compile Include="EndToEnd\UserDataNestedTypesTests.cs" />

--- a/src/MoonSharp.Interpreter/CoreLib/OsTimeModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/OsTimeModule.cs
@@ -123,7 +123,9 @@ namespace MoonSharp.Interpreter.CoreLib
 
 				try
 				{
-					reference = TimeZoneInfo.ConvertTimeFromUtc(reference, TimeZoneInfo.Local);
+					TimeZoneInfo localTimeZoneInfo = executionContext.OwnerScript.Options.LocalTimeZoneInfo ?? TimeZoneInfo.Local;
+
+					reference = TimeZoneInfo.ConvertTimeFromUtc(reference, localTimeZoneInfo);
 					isDst = reference.IsDaylightSavingTime();
 				}
 				catch (TimeZoneNotFoundException)

--- a/src/MoonSharp.Interpreter/ScriptOptions.cs
+++ b/src/MoonSharp.Interpreter/ScriptOptions.cs
@@ -27,6 +27,8 @@ namespace MoonSharp.Interpreter
 			this.ScriptLoader = defaults.ScriptLoader;
 
 			this.CheckThreadAccess = defaults.CheckThreadAccess;
+
+			this.LocalTimeZoneInfo = defaults.LocalTimeZoneInfo;
 		}
 
 		/// <summary>
@@ -88,13 +90,17 @@ namespace MoonSharp.Interpreter
 		/// Gets or sets a value indicating whether the thread check is enabled.
 		/// A "lazy" thread check is performed everytime execution is entered to ensure that no two threads
 		/// calls MoonSharp execution concurrently. However 1) the check is performed best effort (thus, it might
-		/// not detect all issues) and 2) it might trigger in very odd legal situations (like, switching threads 
+		/// not detect all issues) and 2) it might trigger in very odd legal situations (like, switching threads
 		/// inside a CLR-callback without actually having concurrency.
-		/// 
+		///
 		/// Disable this option if the thread check is giving problems in your scenario, but please check that
 		/// you are not calling MoonSharp execution concurrently as it is not supported.
 		/// </summary>
 		public bool CheckThreadAccess { get; set; }
 
+		/// <summary>
+		/// Gets or sets the local time zone. If null, TimeZoneInfo.Local is used.
+		/// </summary>
+		public TimeZoneInfo LocalTimeZoneInfo { get; set; }
 	}
 }


### PR DESCRIPTION
TimeZone used by os.time () is hard coded in TimeZoneInfo.LocalTime, but by applying this pull request, it can be changed for each Script object.

ex)

```csharp
Script S = new Script();
// set your preferred TimeZoneInfo
S.Options.LocalTimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
// You can get local time different from the system time zone
DynValue res = S.DoString("return os.date(\"%Y-%m-%d %H:%M:%S\")");
```