### PR TITLE
To meet module naming convention

### DIFF
--- a/src/MoonSharp.Interpreter/Loaders/EmbeddedResourcesScriptLoader.cs
+++ b/src/MoonSharp.Interpreter/Loaders/EmbeddedResourcesScriptLoader.cs
@@ -31,7 +31,9 @@ namespace MoonSharp.Interpreter.Loaders
 
 			m_ResourceAssembly = resourceAssembly;
 			m_Namespace = m_ResourceAssembly.FullName.Split(',').First();
-			m_ResourceNames = new HashSet<string>(m_ResourceAssembly.GetManifestResourceNames());
+            m_Namespace = m_Namespace.Replace('-', '_');
+
+            m_ResourceNames = new HashSet<string>(m_ResourceAssembly.GetManifestResourceNames());
 		}
 
 		private string FileNameToResource(string file)


### PR DESCRIPTION
This patch is aimed at fixing an error with embedded module names containing hyphens. Visual Studio converts the hyphen into an underscore, however the Moonsharp library does not replace the hyphen with an underscore, this prevents an embedded LUA script from being loaded.

According to Microsoft documentation (see
http://stackoverflow.com/questions/14705211/how-is-net-renaming-my-embedded-resources)
module names may not include hyphens and should be replaced by an
underscores.

