### PR TITLE
Fixes another NullReferenceException in debug.getmetatable

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/DebugModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/DebugModule.cs
@@ -82,7 +82,7 @@ namespace MoonSharp.Interpreter.CoreLib
 			DynValue v = args[0];
 			Script S = executionContext.GetScript();
 
-			if (v.Type.CanHaveTypeMetatables())
+			if (v.Type.CanHaveTypeMetatables() && S.GetTypeMetatable(v.Type) != null)
 				return DynValue.NewTable(S.GetTypeMetatable(v.Type));
 			else if (v.Type == DataType.Table)
 				return DynValue.NewTable(v.Table.MetaTable);


### PR DESCRIPTION
Just because a Lua type can have a metatable, doesn't mean it does. Before this change, the following would throw a NullReferenceException:

```
local m = debug.getmetatable(true)
print(m)
```

Now, it won't. The extension method CanHaveTypeMetatables only checks if it's legal for the given type to have a Table, not if it does. I suppose this could be simplified with the addition of a HasTypeMetatable(), or something similar.