### PR TITLE
Enumerator based coroutine yielding

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/CoroutineModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/CoroutineModule.cs
@@ -121,7 +121,18 @@ namespace MoonSharp.Interpreter.CoreLib
 			}
 	
 		}
-
+		
+		[MoonSharpModuleMethod]
+		public static DynValue is_return_value(ScriptExecutionContext executionContext, CallbackArguments args)
+		{
+			return args[0].Type == DataType.ClrCoroutineReturn ? DynValue.True : DynValue.False;
+		}
+		
+		[MoonSharpModuleMethod]
+		public static DynValue get_return_value(ScriptExecutionContext executionContext, CallbackArguments args)
+		{
+			return args[0].Type == DataType.ClrCoroutineReturn ? args[0].ClrCoroutineReturnValue : DynValue.Nil;
+		}
 
 	}
 }

--- a/src/MoonSharp.Interpreter/DataTypes/DataType.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/DataType.cs
@@ -64,6 +64,10 @@ namespace MoonSharp.Interpreter
 		/// A request to coroutine.yield
 		/// </summary>
 		YieldRequest,
+		/// <summary>
+		/// Return a value from a clr coroutine
+		/// </summary>
+		ClrCoroutineReturn,
 	}
 
 	/// <summary>
@@ -114,6 +118,8 @@ namespace MoonSharp.Interpreter
 					return "userdata";
 				case DataType.Thread:
 					return "coroutine";
+				case DataType.ClrCoroutineReturn:
+					return "coroutine_return";
 				case DataType.Tuple:
 				case DataType.TailCallRequest:
 				case DataType.YieldRequest:
@@ -164,6 +170,8 @@ namespace MoonSharp.Interpreter
 					return "userdata";
 				case DataType.Thread:
 					return "thread";
+				case DataType.ClrCoroutineReturn:
+					return "coroutine_return";
 				case DataType.Tuple:
 				case DataType.TailCallRequest:
 				case DataType.YieldRequest:

--- a/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
@@ -76,6 +76,11 @@ namespace MoonSharp.Interpreter
 		/// Gets the tail call data.
 		/// </summary>
 		public UserData UserData { get { return m_Object as UserData; } }
+		
+		/// <summary>
+		/// Gets the clr couroutine return value
+		/// </summary>
+		public DynValue ClrCoroutineReturnValue { get { return m_Object as DynValue; } }
 
 		/// <summary>
 		/// Returns true if this instance is write protected.
@@ -370,6 +375,14 @@ namespace MoonSharp.Interpreter
 			{
 				m_Object = userData,
 				m_Type = DataType.UserData,
+			};
+		}
+
+		public static DynValue NewClrCoroutineReturn(DynValue returnedValue) {
+			return new DynValue()
+			{
+				m_Object = returnedValue,
+				m_Type = DataType.ClrCoroutineReturn,
 			};
 		}
 

--- a/src/MoonSharp.Interpreter/Interop/Attributes/MoonSharpClrCoroutineAttribute.cs
+++ b/src/MoonSharp.Interpreter/Interop/Attributes/MoonSharpClrCoroutineAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace MoonSharp.Interpreter
+{
+    /// <summary>
+    /// Marks a method as a clr enumerator based coroutine
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    public sealed class MoonSharpClrCoroutineAttribute : Attribute
+	{
+        public MoonSharpClrCoroutineAttribute()
+		{
+        }
+    }
+}

--- a/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
+++ b/src/MoonSharp.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
@@ -178,7 +178,7 @@ namespace MoonSharp.Interpreter.Interop.BasicDescriptors
 		{
 			IOverloadableMemberDescriptor odesc = desc as IOverloadableMemberDescriptor;
 
-			if (odesc != null)
+			if (odesc != null && !(desc is MethodMemberDescriptorCoroutine))
 			{
 				if (members.ContainsKey(name))
 				{

--- a/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptorCoroutine.cs
+++ b/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptorCoroutine.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+
+namespace MoonSharp.Interpreter.Interop 
+{
+    public class MethodMemberDescriptorCoroutine : MethodMemberDescriptor 
+	{
+        public MethodMemberDescriptorCoroutine(MethodBase methodBase, InteropAccessMode accessMode = InteropAccessMode.Default) : base(methodBase, accessMode) 
+		{
+        }
+
+        public override DynValue GetValue(Script script, object obj) 
+		{
+            var enumerateYielder = script.DoString(@"return function (callable) 
+    return function (...)
+        for y in callable(...) do
+            coroutine.yield(y)
+        end
+    end
+end");
+            return script.Call(enumerateYielder, base.GetValue(script, obj));
+        }
+        
+        /// Tries to create a new MethodMemberDescriptorCoroutine, returning 
+        /// <c>null</c> in case the method is not
+        /// visible to script code.
+        /// </summary>
+        /// <param name="methodBase">The MethodBase.</param>
+        /// <param name="accessMode">The <see cref="InteropAccessMode" /></param>
+        /// <param name="forceVisibility">if set to <c>true</c> forces visibility.</param>
+        /// <returns>
+        /// A new MethodMemberDescriptor or null.
+        /// </returns>
+        public static MethodMemberDescriptorCoroutine TryCreateCoroutineIfVisible(MethodBase methodBase, InteropAccessMode accessMode, bool forceVisibility = false)
+        {
+            if (!CheckMethodIsCompatible(methodBase, false))
+                return null;
+
+            if (forceVisibility || (methodBase.GetVisibilityFromAttributes() ?? methodBase.IsPublic))
+                return new MethodMemberDescriptorCoroutine(methodBase, accessMode);
+
+            return null;
+        }
+    }
+}

--- a/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptorCoroutine.cs
+++ b/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptorCoroutine.cs
@@ -13,10 +13,14 @@ namespace MoonSharp.Interpreter.Interop
             var enumerateYielder = script.DoString(@"return function (callable) 
     return function (...)
         for y in callable(...) do
-            coroutine.yield(y)
+            if coroutine.is_return_value(y) then
+                return coroutine.get_return_value(y)
+            else 
+                coroutine.yield(y)
+            end
         end
     end
-end");
+end", null, MethodInfo + "_yielder");
             return script.Call(enumerateYielder, base.GetValue(script, obj));
         }
         

--- a/src/MoonSharp.Interpreter/Interop/StandardDescriptors/StandardUserDataDescriptor.cs
+++ b/src/MoonSharp.Interpreter/Interop/StandardDescriptors/StandardUserDataDescriptor.cs
@@ -78,7 +78,12 @@ namespace MoonSharp.Interpreter.Interop
 			{
 				if (membersToIgnore.Contains(mi.Name)) continue;
 
-				MethodMemberDescriptor md = MethodMemberDescriptor.TryCreateIfVisible(mi, this.AccessMode);
+				MethodMemberDescriptor md;
+				if (mi.CustomAttributes.Any(data => data.AttributeType == typeof(MoonSharpClrCoroutineAttribute))) {
+					md = MethodMemberDescriptorCoroutine.TryCreateCoroutineIfVisible(mi, this.AccessMode);
+				} else {
+					md = MethodMemberDescriptor.TryCreateIfVisible(mi, this.AccessMode);
+				}
 
 				if (md != null)
 				{


### PR DESCRIPTION
Hey!
One of the features that's missing from moonsharp that'd make writing lua code a lot more elegant would be support for yielding a coroutine in clr functions
In unity this is usually done by just having an enumerator/generator function (not sure of the 100% correct terminology):
```c#
    IEnumerator MyCoroutine(int counter) {
        for (int i = 0: i < counter; i++) {
            yield return i;
        }
    }
```
You can do something like this already, but you'll have to manually keep track of the iterator:
```lua
    for i in my_coroutine(10) do
        coroutine.yield(i)
    end
```

Conceptually it shouldn't be too hard to just add some "syntactical sugar" to implement something similar to the lua function above behind the scenes.. 
So I decided to give that a try and went digging
First I looked at the custom converters and figured it'd be as easy as checking for an attribute on the method info and just giving it a different DynValue with the "for loop yield" part, but turns out classes don't even use that and I had to go a lot deeper
```c#
    [MoonSharpClrCoroutine]
    IEnumerator YieldExample(int counter) {
        for (int i = 0: i < counter; i++) {
            yield return i;
        }
    }
```
This is obviously a giant hack at the moment and I'm mainly looking for feedback to get this to a decent state where merging it might be considered
The whole MethodMemberDescriptor part can be implemented better, but I didn't want to dig too deep into the scary parts for a proof of concept
I'm also curious what the best way would be to generate the iterator wrapper part? From what I gathered the yield does need to be run in bytecode currently

