### PR TITLE
Fix of incorrect work of the split string with the Cyrillic symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+/.vs

--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
@@ -238,6 +238,15 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			";
 			DynValue res = S.DoString(script);
 		}
+		[Test]
+        public void String_GSub_4()
+        {
+            string script = @"
+				return string.gsub('Ррррр Нннннн Сссссс','%S+', 'Z')
+			";
+            DynValue res = Script.RunString(script);
+			Assert.AreEqual("Z Z Z", res.Tuple[0].String);
+		}
 
 		[Test]
 		public void String_Match_1()

--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/StringLibTests.cs
@@ -27,6 +27,23 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			Assert.AreEqual(DataType.String, res.Type);
 			Assert.AreEqual("HelloLuauser", res.String);
 		}
+        [Test]
+		public void String_GMatch_2()
+		{
+			string script = @"    
+                s = 'Ррррр Нннннн Сссссс'
+                words = {}
+                for word in s:gmatch('%w+') do table.insert(words, word) end
+                return words
+			";
+
+			DynValue res = Script.RunString(script);
+			Assert.AreEqual(3, res.Table.Length);
+			Assert.AreEqual("Ррррр", res.Table.Get(1).String);
+			Assert.AreEqual("Нннннн", res.Table.Get(2).String);
+			Assert.AreEqual("Сссссс", res.Table.Get(3).String);
+
+		}
 
 		[Test]
 		public void String_Find_1()

--- a/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/StringLib/KopiLua_StrLib.cs
@@ -252,7 +252,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 										 CharPtr p, CharPtr ep)
 		{
 			ptrdiff_t i = 0;  /* counts maximum expand for item */
-			while ((s + i < ms.src_end) && (singlematch((byte)(s[i]), p, ep) != 0))
+			while ((s + i < ms.src_end) && (singlematch(s[i], p, ep) != 0))
 				i++;
 			/* keeps trying to match with the maximum repetitions */
 			while (i >= 0)
@@ -273,7 +273,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				CharPtr res = match(ms, s, ep + 1);
 				if (res != null)
 					return res;
-				else if ((s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0))
+				else if ((s < ms.src_end) && (singlematch(s[0], p, ep) != 0))
 					s = s.next();  /* try with one more repetition */
 				else return null;
 			}
@@ -374,7 +374,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 									//ismeretlen hiba miatt lett ide átmásolva
 									{  /* it is a pattern item */
 										CharPtr ep = classend(ms, p);  /* points to what is next */
-										int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+										int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 										switch (ep[0])
 										{
 											case '?':
@@ -421,7 +421,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				dflt:
 					{  /* it is a pattern item */
 						CharPtr ep = classend(ms, p);  /* points to what is next */
-						int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+						int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 						switch (ep[0])
 						{
 							case '?':

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/CoreLib/StringLib/KopiLua_StrLib.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/CoreLib/StringLib/KopiLua_StrLib.cs
@@ -252,7 +252,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 										 CharPtr p, CharPtr ep)
 		{
 			ptrdiff_t i = 0;  /* counts maximum expand for item */
-			while ((s + i < ms.src_end) && (singlematch((byte)(s[i]), p, ep) != 0))
+			while ((s + i < ms.src_end) && (singlematch(s[i], p, ep) != 0))
 				i++;
 			/* keeps trying to match with the maximum repetitions */
 			while (i >= 0)
@@ -273,7 +273,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				CharPtr res = match(ms, s, ep + 1);
 				if (res != null)
 					return res;
-				else if ((s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0))
+				else if ((s < ms.src_end) && (singlematch(s[0], p, ep) != 0))
 					s = s.next();  /* try with one more repetition */
 				else return null;
 			}
@@ -374,7 +374,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 									//ismeretlen hiba miatt lett ide átmásolva
 									{  /* it is a pattern item */
 										CharPtr ep = classend(ms, p);  /* points to what is next */
-										int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+										int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 										switch (ep[0])
 										{
 											case '?':
@@ -421,7 +421,7 @@ namespace MoonSharp.Interpreter.CoreLib.StringLib
 				dflt:
 					{  /* it is a pattern item */
 						CharPtr ep = classend(ms, p);  /* points to what is next */
-						int m = (s < ms.src_end) && (singlematch((byte)(s[0]), p, ep) != 0) ? 1 : 0;
+						int m = (s < ms.src_end) && (singlematch(s[0], p, ep) != 0) ? 1 : 0;
 						switch (ep[0])
 						{
 							case '?':


### PR DESCRIPTION
Splitting a string containing the Cyrillic symbols using the gmatch method has wrong result, for example:
```
                s = 'Ррррр Нннннн Сссссс'
                words = {}
                for word in s:gmatch('%w+') do table.insert(words, word) end
                return words
```
Returns a table containing one row, although the correct result is three rows.

Added a solution to this problem and a couple of tests. I didn't quite understand why in KopiLua when working with strings ```char``` is often cast to ```byte```, causes there is a loss of information, which leads to such bugs.
