### PR TITLE
Compound assignment operators (e.g. "+=")

### DIFF
--- a/src/MoonSharp.Interpreter/Tree/Lexer/Lexer.cs
+++ b/src/MoonSharp.Interpreter/Tree/Lexer/Lexer.cs
@@ -182,7 +182,7 @@ namespace MoonSharp.Interpreter.Tree
 							return CreateToken(TokenType.Dot, fromLine, fromCol, ".");
 					}
 				case '+':
-					return CreateSingleCharToken(TokenType.Op_Add, fromLine, fromCol);
+					return PotentiallyDoubleCharOperator('=', TokenType.Op_Add, TokenType.Op_Assignment, fromLine, fromCol);
 				case '-':
 					{
 						char next = CursorCharNext();
@@ -190,19 +190,24 @@ namespace MoonSharp.Interpreter.Tree
 						{
 							return ReadComment(fromLine, fromCol);
 						}
+						else if (next == '=')
+						{
+							CursorCharNext();
+							return CreateToken(TokenType.Op_Assignment, fromLine, fromCol, "-=");
+						}
 						else
 						{
 							return CreateToken(TokenType.Op_MinusOrSub, fromLine, fromCol, "-");
 						}
 					}
 				case '*':
-					return CreateSingleCharToken(TokenType.Op_Mul, fromLine, fromCol);
+					return PotentiallyDoubleCharOperator('=', TokenType.Op_Mul, TokenType.Op_Assignment, fromLine, fromCol);
 				case '/':
-					return CreateSingleCharToken(TokenType.Op_Div, fromLine, fromCol);
+					return PotentiallyDoubleCharOperator('=', TokenType.Op_Div, TokenType.Op_Assignment, fromLine, fromCol);
 				case '%':
-					return CreateSingleCharToken(TokenType.Op_Mod, fromLine, fromCol);
+					return PotentiallyDoubleCharOperator('=', TokenType.Op_Mod, TokenType.Op_Assignment, fromLine, fromCol);
 				case '^':
-					return CreateSingleCharToken(TokenType.Op_Pwr, fromLine, fromCol);
+					return PotentiallyDoubleCharOperator('=', TokenType.Op_Pwr, TokenType.Op_Assignment, fromLine, fromCol);
 				case '$':
 					return PotentiallyDoubleCharOperator('{', TokenType.Op_Dollar, TokenType.Brk_Open_Curly_Shared, fromLine, fromCol);
 				case '#':

--- a/src/MoonSharp.Interpreter/Tree/Lexer/Lexer.cs
+++ b/src/MoonSharp.Interpreter/Tree/Lexer/Lexer.cs
@@ -175,7 +175,7 @@ namespace MoonSharp.Interpreter.Tree
 					{
 						char next = CursorCharNext();
 						if (next == '.')
-							return PotentiallyDoubleCharOperator('.', TokenType.Op_Concat, TokenType.VarArgs, fromLine, fromCol);
+							return PotentiallyDoubleCharOperator(TokenType.Op_Concat, '.', TokenType.VarArgs, "...", '=', TokenType.Op_Assignment, "..=", fromLine, fromCol);
 						else if (LexerUtils.CharIsDigit(next))
 							return ReadNumberToken(fromLine, fromCol, true);
 						else
@@ -545,8 +545,25 @@ namespace MoonSharp.Interpreter.Tree
 			else
 				return CreateToken(singleCharToken, fromLine, fromCol, op);
 		}
+		private Token PotentiallyDoubleCharOperator(TokenType singleCharToken, char expectedSecondChar, TokenType doubleCharToken, string doubleCharText, char alternateExpectedSecondChar, TokenType alternateDoubleCharToken, string alternateDoubleCharText, int fromLine, int fromCol)
+		{
+			string op = CursorChar().ToString();
 
+			CursorCharNext();
 
+			if (CursorChar() == expectedSecondChar)
+			{
+				CursorCharNext();
+				return CreateToken(doubleCharToken, fromLine, fromCol, doubleCharText);
+			}
+			else if (CursorChar() == alternateExpectedSecondChar)
+			{
+				CursorCharNext();
+				return CreateToken(alternateDoubleCharToken, fromLine, fromCol, alternateDoubleCharText);
+			}
+			else
+				return CreateToken(singleCharToken, fromLine, fromCol, op);
+		}
 
 		private Token CreateNameToken(string name, int fromLine, int fromCol)
 		{
@@ -561,7 +578,6 @@ namespace MoonSharp.Interpreter.Tree
 				return CreateToken(TokenType.Name, fromLine, fromCol, name);
 			}
 		}
-
 
 		private Token CreateToken(TokenType tokenType, int fromLine, int fromCol, string text = null)
 		{
@@ -588,9 +604,5 @@ namespace MoonSharp.Interpreter.Tree
 
 			return name.ToString();
 		}
-
-
-
-
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Statement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statement.cs
@@ -39,7 +39,7 @@ namespace MoonSharp.Interpreter.Tree
 				case TokenType.Function:
 					return new FunctionDefinitionStatement(lcontext, false, null);
 				case TokenType.Local:
-					Token localToken = lcontext.Lexer.Current;
+					Token localToken = tkn;
 					lcontext.Lexer.Next();
 					if (lcontext.Lexer.Current.Type == TokenType.Function)
 						return new FunctionDefinitionStatement(lcontext, true, localToken);
@@ -52,15 +52,13 @@ namespace MoonSharp.Interpreter.Tree
 					return new BreakStatement(lcontext);
 				default:
 					{
-						Token l = lcontext.Lexer.Current;
 						Expression exp = Expression.PrimaryExp(lcontext);
-						FunctionCallExpression fnexp = exp as FunctionCallExpression;
 
-						if (fnexp != null)
-							return new FunctionCallStatement(lcontext, fnexp);
-						else
-							return new AssignmentStatement(lcontext, exp, l);
-					}
+                        if (exp is FunctionCallExpression fnexp)
+                            return new FunctionCallStatement(lcontext, fnexp);
+                        else
+                            return new AssignmentStatement(lcontext, exp, tkn);
+                    }
 			}
 		}
 

--- a/src/MoonSharp.Interpreter/Tree/Statement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statement.cs
@@ -54,11 +54,11 @@ namespace MoonSharp.Interpreter.Tree
 					{
 						Expression exp = Expression.PrimaryExp(lcontext);
 
-                        if (exp is FunctionCallExpression fnexp)
-                            return new FunctionCallStatement(lcontext, fnexp);
-                        else
-                            return new AssignmentStatement(lcontext, exp, tkn);
-                    }
+						if (exp is FunctionCallExpression fnexp)
+							return new FunctionCallStatement(lcontext, fnexp);
+						else
+							return new AssignmentStatement(lcontext, exp, tkn);
+					}
 			}
 		}
 

--- a/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
@@ -68,23 +68,24 @@ namespace MoonSharp.Interpreter.Tree.Statements
 				m_LValues.Add(CheckVar(lcontext, e));
 			}
 
-			char assignmentType = lcontext.Lexer.Current.Text[0];
+			string assignmentType = lcontext.Lexer.Current.Text;
 
 			CheckTokenType(lcontext, TokenType.Op_Assignment);
 
 			m_RValues = Expression.ExprList(lcontext);
 
 			// Replace e.g. "a += b" with "a = a + b"
-			if (assignmentType != '=')
+			if (assignmentType != "=")
 			{
 				TokenType ArithmeticOperation = assignmentType switch
 				{
-					'+' => TokenType.Op_Add,
-					'-' => TokenType.Op_MinusOrSub,
-					'*' => TokenType.Op_Mul,
-					'/' => TokenType.Op_Div,
-					'%' => TokenType.Op_Mod,
-					'^' => TokenType.Op_Pwr,
+					"+=" => TokenType.Op_Add,
+					"-=" => TokenType.Op_MinusOrSub,
+					"*=" => TokenType.Op_Mul,
+					"/=" => TokenType.Op_Div,
+					"%=" => TokenType.Op_Mod,
+					"^=" => TokenType.Op_Pwr,
+					"..=" => TokenType.Op_Concat,
 					_ => throw new InternalErrorException($"Assignment operator not recognised: {assignmentType}"),
 				};
 

--- a/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
@@ -77,7 +77,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 			// Replace e.g. "a += b" with "a = a + b"
 			if (assignmentType != "=")
 			{
-				TokenType ArithmeticOperation = assignmentType switch
+				TokenType operationTokenType = assignmentType switch
 				{
 					"+=" => TokenType.Op_Add,
 					"-=" => TokenType.Op_MinusOrSub,
@@ -91,7 +91,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 
 				object operatorChain = BinaryOperatorExpression.BeginOperatorChain();
 				BinaryOperatorExpression.AddExpressionToChain(operatorChain, firstExpression);
-				BinaryOperatorExpression.AddOperatorToChain(operatorChain, new Token(ArithmeticOperation, first.SourceId, first.FromLine, first.FromCol, first.ToLine, first.ToCol, first.PrevLine, first.PrevCol));
+				BinaryOperatorExpression.AddOperatorToChain(operatorChain, new Token(operationTokenType, first.SourceId, first.FromLine, first.FromCol, first.ToLine, first.ToCol, first.PrevLine, first.PrevCol));
 				BinaryOperatorExpression.AddExpressionToChain(operatorChain, m_RValues[0]);
 				m_RValues[0] = BinaryOperatorExpression.CommitOperatorChain(operatorChain, lcontext);
 			}


### PR DESCRIPTION
Adds support for: `+=`, `-=`, `*=`, `/=`, `%=`, `^=`, and `..=`.

While these operators are not present in Lua, they are present in [Luau](https://github.com/Roblox/luau) and save a lot of time.

Example:
```
local a = 0
a += 5
print(a)
```

Converts to:
```
local a = 0
a = a + 5
print(a)
```