### PR TITLE
Fix for #198 (var args are nil when void is passed)

### DIFF
--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -642,7 +642,18 @@ namespace MoonSharp.Interpreter.Execution.VM
 			{
 				if (i >= argsList.Count)
 				{
-					this.AssignLocal(I.SymbolList[i], DynValue.NewNil());
+					var stackframe = m_ExecutionStack.Peek();
+					SymbolRef symref = I.SymbolList[i];
+
+					bool nothingWasPassedToVarArgs = symref.i_Name == WellKnownSymbols.VARARGS;
+					if (nothingWasPassedToVarArgs)
+					{
+						stackframe.LocalScope[symref.i_Index] = DynValue.Void;
+					}
+					else
+					{
+						this.AssignLocal(symref, DynValue.NewNil());
+					}
 				}
 				else if ((i == I.SymbolList.Length - 1) && (I.SymbolList[i].i_Name == WellKnownSymbols.VARARGS))
 				{


### PR DESCRIPTION
```
function x(...)
  print(select('#', ...))
end
x()
```
Previous output: `1`
New output: `0`

Previously, when nothing was passed to variadic arguments (...) it would actually pass nil. With the fix, it passes nothing.