### PR TITLE
DynValue ToString uses InvariantCulture

### DIFF
--- a/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/DynValue.cs
@@ -687,7 +687,7 @@ namespace MoonSharp.Interpreter
 			DynValue rv = ToScalar();
 			if (rv.Type == DataType.Number)
 			{
-				return rv.Number.ToString();
+				return rv.Number.ToString(CultureInfo.InvariantCulture);
 			}
 			else if (rv.Type == DataType.String)
 			{

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/DataTypes/DynValue.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/DataTypes/DynValue.cs
@@ -687,7 +687,7 @@ namespace MoonSharp.Interpreter
 			DynValue rv = ToScalar();
 			if (rv.Type == DataType.Number)
 			{
-				return rv.Number.ToString();
+				return rv.Number.ToString(CultureInfo.InvariantCulture);
 			}
 			else if (rv.Type == DataType.String)
 			{


### PR DESCRIPTION
Performing this change allows decimal values to concatenate through strings correctly.
When a user's Windows regional format uses `,` for decimal separation, MoonSharp does not handle it in this instance.
For my purposes, I have a software that uses MoonSharp for FFmpeg operations.
This is a snippet from a Lua script that does not execute correctly:
```lua
-- Cut material to whatthe length from random start
local multiplier = (whatthelength*0.75)
local start = functions.randomDouble(0, materiallength - multiplier)
functions.runFFmpeg("-ss " .. start .. " -i \"" .. material .. "\" -t " .. multiplier .. " -c:v libx264 -preset ultrafast -crf 18 -vf scale=" .. options.width .. ":" .. options.height .. ",setsar=1:1,fps=fps=30 -y \"" .. temp2 .. "\"")
```
The values `start` and `multiplier` may not output in a valid format, resulting in this error:
```
Invalid duration specification for ss: 0,5253521033538923
```
After these changes were made, the issue no longer occurs.
This may be considered a duplicate or continuation of #295.