### PR TITLE
Bitwise operators and floor division operator from Lua 5.3

### DIFF
--- a/src/MoonSharp.Interpreter/Execution/InstructionFieldUsage.cs
+++ b/src/MoonSharp.Interpreter/Execution/InstructionFieldUsage.cs
@@ -35,6 +35,7 @@ namespace MoonSharp.Interpreter.Execution
 				case OpCode.Sub:
 				case OpCode.Mul:
 				case OpCode.Div:
+				case OpCode.FloorDiv:
 				case OpCode.Mod:
 				case OpCode.Not:
 				case OpCode.Len:
@@ -42,6 +43,12 @@ namespace MoonSharp.Interpreter.Execution
 				case OpCode.Power:
 				case OpCode.CNot:
 				case OpCode.ToBool:
+				case OpCode.BitwiseAnd:
+				case OpCode.BitwiseOr:
+				case OpCode.BitwiseXor:
+				case OpCode.BitwiseLShift:
+				case OpCode.BitwiseRShift:
+				case OpCode.BitwiseNot:
 					return InstructionFieldUsage.None;
 				case OpCode.Pop:
 				case OpCode.Copy:

--- a/src/MoonSharp.Interpreter/Execution/VM/OpCode.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/OpCode.cs
@@ -50,12 +50,19 @@ namespace MoonSharp.Interpreter.Execution.VM
 		Sub,		// Subtraction of the two topmost operands on the v-stack
 		Mul,		// Multiplication of the two topmost operands on the v-stack
 		Div,		// Division of the two topmost operands on the v-stack
+		FloorDiv,		// Floor Division of the two topmost operands on the v-stack
 		Mod,		// Modulus of the two topmost operands on the v-stack
 		Not,		// Logical inversion of the topmost operand on the v-stack
 		Len,		// Size operator of the topmost operand on the v-stack
 		Neg,		// Negation (unary minus) operator of the topmost operand on the v-stack
 		Power,		// Power of the two topmost operands on the v-stack
 		CNot,		// Conditional NOT - takes second operand from the v-stack (must be bool), if true execs a NOT otherwise execs a TOBOOL
+		BitwiseAnd,	// Bitwise AND of the two topmost operands on the v-stack
+		BitwiseOr,	// Bitwise OR of the two topmost operands on the v-stack
+		BitwiseXor,	// Bitwise XOR of the two topmost operands on the v-stack
+		BitwiseLShift,	// Bitwise Left Shift of the two topmost operands on the v-stack
+		BitwiseRShift,	// Bitwise Right Shift of the two topmost operands on the v-stack
+		BitwiseNot,	// Unary Bitwise NOT of the topmost operand on the v-stack
 
 
 		// Type conversions and manipulations

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -74,6 +74,10 @@ namespace MoonSharp.Interpreter.Execution.VM
 							instructionPtr = ExecNeg(i, instructionPtr);
 							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
 							break;
+						case OpCode.BitwiseNot:
+							instructionPtr = ExecBitwiseNot(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
 						case OpCode.Sub:
 							instructionPtr = ExecSub(i, instructionPtr);
 							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
@@ -86,12 +90,36 @@ namespace MoonSharp.Interpreter.Execution.VM
 							instructionPtr = ExecDiv(i, instructionPtr);
 							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
 							break;
+						case OpCode.FloorDiv:
+							instructionPtr = ExecFloorDiv(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
 						case OpCode.Mod:
 							instructionPtr = ExecMod(i, instructionPtr);
 							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
 							break;
 						case OpCode.Power:
 							instructionPtr = ExecPower(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
+						case OpCode.BitwiseAnd:
+							instructionPtr = ExecBitwiseAnd(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
+						case OpCode.BitwiseOr:
+							instructionPtr = ExecBitwiseOr(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
+						case OpCode.BitwiseXor:
+							instructionPtr = ExecBitwiseXor(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
+						case OpCode.BitwiseLShift:
+							instructionPtr = ExecBitwiseLShift(i, instructionPtr);
+							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
+							break;
+						case OpCode.BitwiseRShift:
+							instructionPtr = ExecBitwiseRShift(i, instructionPtr);
 							if (instructionPtr == YIELD_SPECIAL_TRAP) goto yield_to_calling_coroutine;
 							break;
 						case OpCode.Eq:
@@ -993,6 +1021,28 @@ namespace MoonSharp.Interpreter.Execution.VM
 				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
 			}
 		}
+
+		private int ExecFloorDiv(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				m_ValueStack.Push(DynValue.NewNumber(Math.Floor(ln.Value / rn.Value)));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__idiv", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
 		private int ExecPower(Instruction i, int instructionPtr)
 		{
 			DynValue r = m_ValueStack.Pop().ToScalar();
@@ -1015,6 +1065,126 @@ namespace MoonSharp.Interpreter.Execution.VM
 
 		}
 
+		private int ExecBitwiseAnd(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				uint uln = (uint)Math.IEEERemainder(ln.Value, Math.Pow(2.0, 32.0));
+				uint urn = (uint)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+
+				m_ValueStack.Push(DynValue.NewNumber(uln & urn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__band", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
+		private int ExecBitwiseOr(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				uint uln = (uint)Math.IEEERemainder(ln.Value, Math.Pow(2.0, 32.0));
+				uint urn = (uint)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+
+				m_ValueStack.Push(DynValue.NewNumber(uln | urn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__bor", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
+		private int ExecBitwiseXor(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				uint uln = (uint)Math.IEEERemainder(ln.Value, Math.Pow(2.0, 32.0));
+				uint urn = (uint)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+
+				m_ValueStack.Push(DynValue.NewNumber(uln ^ urn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__bxor", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
+		private int ExecBitwiseLShift(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				int iln = (int)Math.IEEERemainder(ln.Value, Math.Pow(2.0, 32.0));
+				int irn = (int)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+
+				m_ValueStack.Push(DynValue.NewNumber(irn < 0 ? iln >> -irn : iln << irn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__shl", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
+		private int ExecBitwiseRShift(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			DynValue l = m_ValueStack.Pop().ToScalar();
+
+			double? rn = r.CastToNumber();
+			double? ln = l.CastToNumber();
+
+			if (ln.HasValue && rn.HasValue)
+			{
+				int iln = (int)Math.IEEERemainder(ln.Value, Math.Pow(2.0, 32.0));
+				int irn = (int)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+
+				m_ValueStack.Push(DynValue.NewNumber(irn < 0 ? iln << -irn : iln >> irn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeBinaryMetaMethod(l, r, "__shr", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
+			}
+		}
+
 		private int ExecNeg(Instruction i, int instructionPtr)
 		{
 			DynValue r = m_ValueStack.Pop().ToScalar();
@@ -1028,6 +1198,25 @@ namespace MoonSharp.Interpreter.Execution.VM
 			else
 			{
 				int ip = Internal_InvokeUnaryMetaMethod(r, "__unm", instructionPtr);
+				if (ip >= 0) return ip;
+				else throw ScriptRuntimeException.ArithmeticOnNonNumber(r);
+			}
+		}
+
+		private int ExecBitwiseNot(Instruction i, int instructionPtr)
+		{
+			DynValue r = m_ValueStack.Pop().ToScalar();
+			double? rn = r.CastToNumber();
+
+			if (rn.HasValue)
+			{
+				uint urn = (uint)Math.IEEERemainder(rn.Value, Math.Pow(2.0, 32.0));
+				m_ValueStack.Push(DynValue.NewNumber(~urn));
+				return instructionPtr;
+			}
+			else
+			{
+				int ip = Internal_InvokeUnaryMetaMethod(r, "__bnot", instructionPtr);
 				if (ip >= 0) return ip;
 				else throw ScriptRuntimeException.ArithmeticOnNonNumber(r);
 			}

--- a/src/MoonSharp.Interpreter/Tree/Expression_.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expression_.cs
@@ -148,7 +148,7 @@ namespace MoonSharp.Interpreter.Tree
 				case TokenType.Function:
 					lcontext.Lexer.Next();
 					return new FunctionDefinitionExpression(lcontext, false, false);
-				case TokenType.Lambda:
+				case TokenType.Op_BitwiseOr_Or_Lambda:
 					return new FunctionDefinitionExpression(lcontext, false, true);
 				default:
 					return PrimaryExp(lcontext);

--- a/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -39,7 +39,7 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 				CheckTokenType(lcontext, TokenType.Function);
 
 			// here lexer should be at the '(' or at the '|'
-			Token openRound = CheckTokenType(lcontext, isLambda ? TokenType.Lambda : TokenType.Brk_Open_Round);
+			Token openRound = CheckTokenType(lcontext, isLambda ? TokenType.Op_BitwiseOr_Or_Lambda : TokenType.Brk_Open_Round);
 
 			List<string> paramnames = BuildParamList(lcontext, pushSelfParam, openRound, isLambda);
 			// here lexer is at first token of body
@@ -102,7 +102,7 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 
 		private List<string> BuildParamList(ScriptLoadingContext lcontext, bool pushSelfParam, Token openBracketToken, bool isLambda)
 		{
-			TokenType closeToken = isLambda ? TokenType.Lambda : TokenType.Brk_Close_Round;
+			TokenType closeToken = isLambda ? TokenType.Op_BitwiseOr_Or_Lambda : TokenType.Brk_Close_Round;
 
 			List<string> paramnames = new List<string>();
 

--- a/src/MoonSharp.Interpreter/Tree/Expressions/UnaryOperatorExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/UnaryOperatorExpression.cs
@@ -32,6 +32,9 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 				case "-":
 					bc.Emit_Operator(OpCode.Neg);
 					break;
+				case "~":
+					bc.Emit_Operator(OpCode.BitwiseNot);
+					break;
 				default:
 					throw new InternalErrorException("Unexpected unary operator '{0}'", m_OpText);
 			}
@@ -55,6 +58,18 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 
 						if (d.HasValue)
 							return DynValue.NewNumber(-d.Value);
+
+						throw new DynamicExpressionException("Attempt to perform arithmetic on non-numbers.");
+					}
+				case "~":
+					{
+						double? d = v.CastToNumber();
+
+						if (d.HasValue)
+						{
+							uint ud = (uint)Math.IEEERemainder(d.Value, Math.Pow(2.0, 32.0));
+							return DynValue.NewNumber(~ud);
+						}
 
 						throw new DynamicExpressionException("Attempt to perform arithmetic on non-numbers.");
 					}

--- a/src/MoonSharp.Interpreter/Tree/Lexer/Token.cs
+++ b/src/MoonSharp.Interpreter/Tree/Lexer/Token.cs
@@ -118,7 +118,16 @@ namespace MoonSharp.Interpreter.Tree
 
 		public bool IsUnaryOperator()
 		{
-			return Type == TokenType.Op_MinusOrSub || Type == TokenType.Not || Type == TokenType.Op_Len;
+			switch (Type)
+			{
+				case TokenType.Op_MinusOrSub:
+				case TokenType.Not:
+				case TokenType.Op_Len:
+				case TokenType.Op_BitwiseXor_Or_BitwiseNot:
+					return true;
+				default:
+					return false;
+			}
 		}
 
 		public bool IsBinaryOperator()
@@ -137,9 +146,15 @@ namespace MoonSharp.Interpreter.Tree
 				case TokenType.Op_Pwr:
 				case TokenType.Op_Mod:
 				case TokenType.Op_Div:
+				case TokenType.Op_FloorDiv:
 				case TokenType.Op_Mul:
 				case TokenType.Op_MinusOrSub:
 				case TokenType.Op_Add:
+				case TokenType.Op_BitwiseAnd:
+				case TokenType.Op_BitwiseOr_Or_Lambda:
+				case TokenType.Op_BitwiseLShift:
+				case TokenType.Op_BitwiseRShift:
+				case TokenType.Op_BitwiseXor_Or_BitwiseNot:
 					return true;
 				default:
 					return false;

--- a/src/MoonSharp.Interpreter/Tree/Lexer/TokenType.cs
+++ b/src/MoonSharp.Interpreter/Tree/Lexer/TokenType.cs
@@ -15,7 +15,7 @@ namespace MoonSharp.Interpreter.Tree
 		False,
 		For,
 		Function,
-		Lambda,
+		Op_BitwiseOr_Or_Lambda,
 		Goto,
 		If,
 		In,
@@ -52,6 +52,7 @@ namespace MoonSharp.Interpreter.Tree
 		Op_Pwr,
 		Op_Mod,
 		Op_Div,
+		Op_FloorDiv,
 		Op_Mul,
 		Op_MinusOrSub,
 		Op_Add,
@@ -68,6 +69,11 @@ namespace MoonSharp.Interpreter.Tree
 
 		Brk_Open_Curly_Shared,
 		Op_Dollar,
+
+		Op_BitwiseAnd,
+		Op_BitwiseXor_Or_BitwiseNot,
+		Op_BitwiseLShift,
+		Op_BitwiseRShift
 	}
 
 


### PR DESCRIPTION
Adds support for bitwise operators `&`, `|`, `~` (XOR and NOT), `<<` and `>>`, as well as `//` from Lua 5.3.

As I understand main reason why these were not implemented in Moonsharp was because it doesn't have an integer type, however I still find these operators useful for running some scripts targeting Lua 5.3. Some other people might find this change valuable as well.