### PR TITLE
Fix for #175 (Inheritance for static methods)

### DIFF
--- a/src/MoonSharp.Interpreter/Compatibility/Frameworks/Base/FrameworkClrBase.cs
+++ b/src/MoonSharp.Interpreter/Compatibility/Frameworks/Base/FrameworkClrBase.cs
@@ -10,7 +10,7 @@ namespace MoonSharp.Interpreter.Compatibility.Frameworks
 {
 	abstract class FrameworkClrBase : FrameworkReflectionBase
 	{
-		BindingFlags BINDINGFLAGS_MEMBER = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+		BindingFlags BINDINGFLAGS_MEMBER = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy;
 		BindingFlags BINDINGFLAGS_INNERCLASS = BindingFlags.Public | BindingFlags.NonPublic;
 
 		public override MethodInfo GetAddMethod(EventInfo ei)


### PR DESCRIPTION
Fix for #175 
When registering a class, static methods of the target base class not get registered even though, other kind of base class members such as fields, properties, or even non-static methods did get registered.
```cs
public void RegisterExampleType()
{
    //Registering Type
    UserData.RegisterType<ExampleClass>();
}

public class ExampleClass : ExampleClassBase
{
    //✅ Get Registered and accessible
    public static int GetStaticValueChild() => 0;
    
    //✅ Get Registered and accessible
    public int ChildMethod() => 0;
}


public class ExampleClassBase
{
    //✅ Get Registered and accessible
    public int BaseMember;
    
    //✅ Get Registered and accessible
    public int NonStaticMethod() => 0; 
    
    //❌ Not get registered 
    public static int StaticBaseMethod() => 0;
}
```
The was because of the `BindingFlags` which `FrameworkClrBase` use to find methods lacks `BindingFlags.FlattenHierarchy` flag which is required for retrieving the static methods from the target base class.

this is a [documented behavior](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethods?view=net-9.0&redirectedfrom=MSDN#System_Type_GetMethods_System_Reflection_BindingFlags_) of `Type.GetMethods(BindingFlags)` method:

> Specify BindingFlags.FlattenHierarchy to include public and protected static members up the hierarchy; private static members in inherited classes are not included.

