### PR TITLE
permit bytecode to use prime tables

### DIFF
--- a/src/MoonSharp.Interpreter/Execution/InstructionFieldUsage.cs
+++ b/src/MoonSharp.Interpreter/Execution/InstructionFieldUsage.cs
@@ -26,7 +26,6 @@ namespace MoonSharp.Interpreter.Execution
 				case OpCode.Scalar:
 				case OpCode.IterUpd:
 				case OpCode.IterPrep:
-				case OpCode.NewTable:
 				case OpCode.Concat:
 				case OpCode.LessEq:
 				case OpCode.Less:
@@ -44,6 +43,7 @@ namespace MoonSharp.Interpreter.Execution
 				case OpCode.ToBool:
 					return InstructionFieldUsage.None;
 				case OpCode.Pop:
+				case OpCode.NewTable:
 				case OpCode.Copy:
 				case OpCode.TblInitI:
 				case OpCode.ExpTuple:

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
@@ -11,7 +11,7 @@ namespace MoonSharp.Interpreter.Execution.VM
 	sealed partial class Processor
 	{
 		const ulong DUMP_CHUNK_MAGIC = 0x1A0D234E4F4F4D1D;
-		const int DUMP_CHUNK_VERSION = 0x150;
+		const int DUMP_CHUNK_VERSION = 0x151;
 
 		internal static bool IsDumpStream(Stream stream)
 		{


### PR DESCRIPTION
a slight oversight when adding Prime Tables: instruction field usage did not get updated to include the new `NumVal` usage for `NewTable`, this fixes that