### PR TITLE
Add support resolve relative source paths using client base path

### DIFF
--- a/src/MoonSharp.VsCodeDebugger/DebuggerLogic/ScriptDebugSession.cs
+++ b/src/MoonSharp.VsCodeDebugger/DebuggerLogic/ScriptDebugSession.cs
@@ -36,6 +36,7 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 		readonly Dictionary<Script, int> m_ThreadIdByScript = new Dictionary<Script, int>();
 		readonly Dictionary<int, VariableReferenceState> m_VariableReferencesById = new Dictionary<int, VariableReferenceState>();
 
+		string m_ClientBasePath;
 		int m_NextThreadId = 1;
 		int m_NextVariableReferenceId = 1;
 		int m_SelectedThreadId = -1;
@@ -332,6 +333,7 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 
 		public override void Attach(Response response, Table arguments)
 		{
+			m_ClientBasePath = arguments?["path"]?.ToString();
 			SendResponse(response);
 		}
 
@@ -545,6 +547,13 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 				SourceRef sourceRef = frame.Location ?? DefaultSourceRef;
 				int sourceIdx = sourceRef.SourceIdx;
 				string sourceFile = state.Debugger.GetSourceFile(sourceIdx);
+
+				// If the source path is relative and the client provided a base path, combine them
+				if (sourceFile != null && m_ClientBasePath != null && !Path.IsPathRooted(sourceFile))
+				{
+					sourceFile = Path.Combine(m_ClientBasePath, sourceFile);
+				}
+
 				SourceCode sourceCode = state.Debugger.GetSource(sourceIdx);
 				bool sourceAvailable = !sourceRef.IsClrLocation && sourceCode != null;
 				int sourceReference = sourceAvailable ? EncodeSourceReference(state.ThreadId, sourceIdx) : 0;
@@ -788,6 +797,15 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 					foreach (var threadState in m_ThreadsById.Values)
 					{
 						SourceCode threadSource = threadState.Debugger.FindSourceByName(path);
+
+						// If no match and client provided a base path, try matching with the relative path
+						if (threadSource == null && m_ClientBasePath != null
+							&& path.StartsWith(m_ClientBasePath, StringComparison.Ordinal))
+						{
+							string relativePath = path.Substring(m_ClientBasePath.Length).TrimStart('/', '\\');
+							threadSource = threadState.Debugger.FindSourceByName(relativePath);
+						}
+
 						if (threadSource != null)
 						{
 							source = threadSource;


### PR DESCRIPTION
When embedding MoonSharp in a server application where scripts are loaded via DoString rather than from files on disk, the sourceFinder callback can only return a relative filename (e.g. 1-Test.lua) since the server doesn't know where the client has the files stored locally.

Currently the VSCode extension's launch.json accepts a path property that defaults to ${workspaceFolder}, but this value is never used by the debug server. The extension sends it in the attach request arguments, but ScriptDebugSession.Attach discards it. This means relative source paths from the sourceFinder are never resolved, and VSCode falls back to requesting source content via DAP and displaying it in a temporary read-only buffer instead of opening the actual workspace file.

This change reads the path argument from the attach request and uses it to resolve relative source paths in two places:

- StackTrace response: if GetSourceFile returns a relative path and the client provided a base path, the two are combined before sending the Source object back to VSCode. This allows VSCode to open the real file from the workspace.

- SetBreakpoints request: when VSCode sends a full absolute path for a breakpoint, and no source matches directly, the base path is stripped and the resulting relative path is tried against known sources. This allows breakpoints set in workspace files to match scripts loaded with relative names.

Our use case is a game server that loads Lua scripts from a database and serves them to developers via WebDAV. Developers mount the WebDAV share as a VSCode workspace and debug remotely through a TCP proxy. The server-side sourceFinder returns just the script filename since it has no knowledge of each developer's local mount path. With this change, the path property in launch.json bridges the gap.