### PR TITLE
Feat/rethrow exceptions stacktrace clean

### DIFF
--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/ErrorHandlingTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/ErrorHandlingTests.cs
@@ -127,5 +127,32 @@ return a()
 			Assert.AreEqual("!cba", res.String);
 		}
 
+		private DynValue MethodWithError()
+		{
+			throw new NullReferenceException();
+		}
+		
+		[Test]
+		public void Errors_Get_OriginalException()
+		{
+			string luaScript = 
+@"
+	callMethodWithError();
+";
+			Script script = new Script(CoreModules.None);
+
+			script.Globals["callMethodWithError"] = DynValue.NewCallback((c, a) => MethodWithError());
+
+			try
+			{
+				DynValue res = script.DoString(luaScript);
+
+			}
+			catch (Exception e)
+			{
+				Assert.IsTrue(e.StackTrace.Contains("MoonSharp.Interpreter.Tests.EndToEnd.ErrorHandlingTests.MethodWithError()"), "Exception should contain c# error line");
+			}
+		}
+
 	}
 }

--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/ErrorHandlingTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/ErrorHandlingTests.cs
@@ -154,5 +154,36 @@ return a()
 			}
 		}
 
+		private class ClassWithMember
+		{
+			public void MethodWithError()
+			{
+				throw new NullReferenceException();
+			}
+		}
+		
+		[Test]
+		public void Errors_Get_OriginalException_WhenUsingMember()
+		{
+			string luaScript = 
+				@"
+	objectWithMethod.MethodWithError();
+";
+			Script script = new Script(CoreModules.None);
+			
+			UserData.RegisterType<ClassWithMember>();
+
+			script.Globals["objectWithMethod"] = new ClassWithMember();
+
+			try
+			{
+				script.DoString(luaScript);
+			}
+			catch (Exception e)
+			{
+				Assert.IsTrue(e.StackTrace.Contains("MoonSharp.Interpreter.Tests.EndToEnd.ErrorHandlingTests.ClassWithMember.MethodWithError() "), "Exception should contain c# error line");
+			}
+		}
+
 	}
 }

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -729,9 +729,9 @@ namespace MoonSharp.Interpreter.Execution.VM
 					m_ValueStack.RemoveLast(argsCount + 1);
 					m_ValueStack.Push(ret);
 				}
-				catch (Exception e)
+				catch
 				{
-					throw e;
+					throw;
 				}
 
 				m_ExecutionStack.Pop();

--- a/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptor.cs
+++ b/src/MoonSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/MethodMemberDescriptor.cs
@@ -212,9 +212,9 @@ namespace MoonSharp.Interpreter.Interop
 
 				return BuildReturnValue(script, outParams, pars, retv);
 			}
-			catch (Exception e)
+			catch
 			{
-				throw e;
+				throw;
 			}
 		}
 


### PR DESCRIPTION
Keep the original stacktrace when there is an error for example on the c# code and it is not a ScriptExecutionException or similar, in that case the throw e was not reusing the original stacktrace, changed to throw , but could even remove the try catch in one case.